### PR TITLE
fix(codex): hoist system/developer input messages into instructions

### DIFF
--- a/relay/channel/codex/adaptor.go
+++ b/relay/channel/codex/adaptor.go
@@ -55,6 +55,18 @@ func (a *Adaptor) ConvertEmbeddingRequest(c *gin.Context, info *relaycommon.Rela
 func (a *Adaptor) ConvertOpenAIResponsesRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.OpenAIResponsesRequest) (any, error) {
 	isCompact := info != nil && info.RelayMode == relayconstant.RelayModeResponsesCompact
 
+	// Generic OpenAI Responses clients (e.g. Pi's openai-responses provider)
+	// embed the system prompt as a system/developer message inside `input`
+	// instead of populating the top-level `instructions` field the way
+	// Codex-native clients do. Hoist it before applying any channel-level
+	// system prompt override below so the two compose the same way they
+	// already do for explicit client-provided instructions.
+	if !isCompact {
+		if err := normalizeResponsesInputInstructions(&request); err != nil {
+			return nil, err
+		}
+	}
+
 	if info != nil && info.ChannelSetting.SystemPrompt != "" {
 		systemPrompt := info.ChannelSetting.SystemPrompt
 

--- a/relay/channel/codex/instructions_normalize.go
+++ b/relay/channel/codex/instructions_normalize.go
@@ -1,0 +1,247 @@
+package codex
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/QuantumNous/new-api/relaykit/dto"
+)
+
+// normalizeResponsesInputInstructions hoists leading system/developer "message"
+// input items into the top-level Instructions field.
+//
+// Codex-native clients (Codex CLI, and Pi's own openai-codex provider) always
+// send the system prompt as a distinct top-level `instructions` string and
+// keep `input` free of system/developer messages. Generic OpenAI Responses
+// clients (e.g. Pi's openai-responses provider, used against non-Codex
+// providers) instead embed the system prompt as the first `input` message
+// with role "system" or "developer" and never populate `instructions`.
+//
+// Forwarding that generic shape to the Codex backend unmodified produces a
+// structurally different request than what Codex-native traffic sends: the
+// system preamble ends up in `input` instead of `instructions`. Codex's own
+// request handling - and by extension its prompt-cache prefix matching -
+// treats `instructions` as a distinct, stable segment from `input`, so this
+// shape mismatch can reduce prompt-cache hit reliability even though the
+// content is semantically identical. This mirrors the "instruction hoisting"
+// step used by other Responses-API-compatible Codex proxies (e.g.
+// github.com/Soju06/codex-lb) to keep the wire shape Codex-native.
+//
+// Responses Lite requests deliberately carry their tool bundle as an `input`
+// item with type "additional_tools" and keep base instructions as a developer
+// message in `input` with an empty top-level `instructions`; that shape is
+// exactly what the Lite upstream expects, so hoisting is skipped whenever an
+// `additional_tools` item is present.
+func normalizeResponsesInputInstructions(request *dto.OpenAIResponsesRequest) error {
+	if len(request.Input) == 0 {
+		return nil
+	}
+
+	var rawItems []json.RawMessage
+	if err := json.Unmarshal(request.Input, &rawItems); err != nil {
+		// Not a JSON array (e.g. a plain string `input`) - nothing to hoist.
+		return nil
+	}
+
+	items := make([]map[string]any, 0, len(rawItems))
+	for _, raw := range rawItems {
+		var m map[string]any
+		if err := json.Unmarshal(raw, &m); err != nil {
+			// Non-object array item - bail out rather than risk corrupting
+			// a shape we don't understand.
+			return nil
+		}
+		items = append(items, m)
+	}
+
+	if responsesInputUsesLiteTools(items) {
+		return nil
+	}
+
+	var instructionParts []string
+	nextItems := make([]map[string]any, 0, len(items))
+	changed := false
+
+	for _, item := range items {
+		if isPreservedNonMessageDirective(item) {
+			// Non-message typed system/developer items (e.g. the Codex
+			// responses-lite additional_tools bundle) carry no instruction
+			// content; pass them through untouched.
+			nextItems = append(nextItems, item)
+			changed = true
+
+			continue
+		}
+
+		role, _ := item["role"].(string)
+		if role != "system" && role != "developer" {
+			nextItems = append(nextItems, item)
+			continue
+		}
+
+		instructionText, preservedContent := splitResponsesInstructionItemContent(item)
+		if instructionText != "" {
+			instructionParts = append(instructionParts, instructionText)
+		}
+
+		if preservedContent != nil {
+			preserved := make(map[string]any, len(item))
+			for k, v := range item {
+				preserved[k] = v
+			}
+
+			preserved["role"] = "user"
+			preserved["content"] = preservedContent
+			nextItems = append(nextItems, preserved)
+		}
+
+		changed = true
+	}
+
+	if !changed {
+		return nil
+	}
+
+	var existingInstructions string
+	if len(request.Instructions) > 0 {
+		_ = json.Unmarshal(request.Instructions, &existingInstructions)
+	}
+
+	merged := mergeResponsesInstructions(existingInstructions, instructionParts)
+
+	mergedBytes, err := json.Marshal(merged)
+	if err != nil {
+		return err
+	}
+
+	itemsBytes, err := json.Marshal(nextItems)
+	if err != nil {
+		return err
+	}
+
+	request.Instructions = mergedBytes
+	request.Input = itemsBytes
+
+	return nil
+}
+
+func responsesInputUsesLiteTools(items []map[string]any) bool {
+	for _, item := range items {
+		if t, _ := item["type"].(string); t == "additional_tools" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isPreservedNonMessageDirective reports whether item is a system/developer
+// input item whose explicit type is something other than "message" (e.g. the
+// Codex responses-lite additional_tools bundle). Such items carry no
+// instruction text and must be forwarded byte-identical.
+func isPreservedNonMessageDirective(item map[string]any) bool {
+	role, _ := item["role"].(string)
+	if role != "system" && role != "developer" {
+		return false
+	}
+
+	itemType, hasType := item["type"]
+	if !hasType || itemType == nil {
+		return false
+	}
+
+	typeStr, _ := itemType.(string)
+
+	return typeStr != "" && typeStr != "message"
+}
+
+// splitResponsesInstructionItemContent extracts hoistable instruction text
+// from a system/developer message item's content, and returns any remaining
+// content (e.g. an embedded image part) that cannot be represented as plain
+// instruction text and must be preserved as a regular input message instead
+// of being silently dropped.
+func splitResponsesInstructionItemContent(item map[string]any) (string, any) {
+	content, hasContent := item["content"]
+	if !hasContent || content == nil {
+		return "", nil
+	}
+
+	if text, ok := content.(string); ok {
+		return text, nil
+	}
+
+	if parts, ok := content.([]any); ok {
+		var instructionParts []string
+
+		var preservedParts []any
+
+		for _, part := range parts {
+			if text, ok := responsesInstructionContentText(part); ok {
+				if text != "" {
+					instructionParts = append(instructionParts, text)
+				}
+
+				continue
+			}
+
+			preservedParts = append(preservedParts, part)
+		}
+
+		var preserved any
+		if len(preservedParts) > 0 {
+			preserved = preservedParts
+		}
+
+		return strings.Join(instructionParts, "\n"), preserved
+	}
+
+	if text, ok := responsesInstructionContentText(content); ok {
+		return text, nil
+	}
+
+	return "", content
+}
+
+// responsesInstructionContentText reports whether content is directly
+// text-extractable (a plain string, or an object carrying a string "text"
+// field, matching input_text/text/output_text-shaped content parts) and
+// returns that text. The second return value is false when content is some
+// other shape (e.g. an image part) that must be preserved instead.
+func responsesInstructionContentText(content any) (string, bool) {
+	if text, ok := content.(string); ok {
+		return text, true
+	}
+
+	m, ok := content.(map[string]any)
+	if !ok {
+		return "", false
+	}
+
+	text, ok := m["text"].(string)
+	if !ok {
+		return "", false
+	}
+
+	return text, true
+}
+
+func mergeResponsesInstructions(existing string, extraParts []string) string {
+	nonEmpty := make([]string, 0, len(extraParts))
+
+	for _, p := range extraParts {
+		if p != "" {
+			nonEmpty = append(nonEmpty, p)
+		}
+	}
+
+	extra := strings.Join(nonEmpty, "\n")
+	if extra == "" {
+		return existing
+	}
+
+	if existing == "" {
+		return extra
+	}
+
+	return existing + "\n" + extra
+}

--- a/relay/channel/codex/instructions_normalize_test.go
+++ b/relay/channel/codex/instructions_normalize_test.go
@@ -1,0 +1,177 @@
+package codex
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/QuantumNous/new-api/relaykit/dto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeResponsesInputInstructions_HoistsSystemRoleStringContent(t *testing.T) {
+	request := &dto.OpenAIResponsesRequest{
+		Input: json.RawMessage(`[
+			{"role":"system","content":"You are a helpful assistant."},
+			{"role":"user","content":"hi"}
+		]`),
+	}
+
+	err := normalizeResponsesInputInstructions(request)
+	require.NoError(t, err)
+
+	var instructions string
+	require.NoError(t, json.Unmarshal(request.Instructions, &instructions))
+	require.Equal(t, "You are a helpful assistant.", instructions)
+
+	var input []map[string]any
+	require.NoError(t, json.Unmarshal(request.Input, &input))
+	require.Len(t, input, 1)
+	require.Equal(t, "user", input[0]["role"])
+}
+
+func TestNormalizeResponsesInputInstructions_HoistsDeveloperRole(t *testing.T) {
+	// Pi's generic openai-responses provider sends role "developer" (not
+	// "system") for reasoning-enabled models, which Codex models are.
+	request := &dto.OpenAIResponsesRequest{
+		Input: json.RawMessage(`[
+			{"role":"developer","content":"You are Pi, a terminal-based coding agent."},
+			{"role":"user","content":"hi"}
+		]`),
+	}
+
+	err := normalizeResponsesInputInstructions(request)
+	require.NoError(t, err)
+
+	var instructions string
+	require.NoError(t, json.Unmarshal(request.Instructions, &instructions))
+	require.Equal(t, "You are Pi, a terminal-based coding agent.", instructions)
+
+	var input []map[string]any
+	require.NoError(t, json.Unmarshal(request.Input, &input))
+	require.Len(t, input, 1)
+	require.Equal(t, "user", input[0]["role"])
+}
+
+func TestNormalizeResponsesInputInstructions_HoistsArrayContentParts(t *testing.T) {
+	request := &dto.OpenAIResponsesRequest{
+		Input: json.RawMessage(`[
+			{"role":"developer","content":[{"type":"input_text","text":"line one"},{"type":"input_text","text":"line two"}]},
+			{"role":"user","content":"hi"}
+		]`),
+	}
+
+	err := normalizeResponsesInputInstructions(request)
+	require.NoError(t, err)
+
+	var instructions string
+	require.NoError(t, json.Unmarshal(request.Instructions, &instructions))
+	require.Equal(t, "line one\nline two", instructions)
+}
+
+func TestNormalizeResponsesInputInstructions_PreservesNonTextContentParts(t *testing.T) {
+	// A system/developer message that also carries an image part cannot be
+	// fully represented as plain instruction text; the non-text part must be
+	// preserved as a regular input message rather than silently dropped.
+	request := &dto.OpenAIResponsesRequest{
+		Input: json.RawMessage(`[
+			{"role":"developer","content":[{"type":"input_text","text":"look at this"},{"type":"input_image","image_url":"https://example.com/a.png"}]}
+		]`),
+	}
+
+	err := normalizeResponsesInputInstructions(request)
+	require.NoError(t, err)
+
+	var instructions string
+	require.NoError(t, json.Unmarshal(request.Instructions, &instructions))
+	require.Equal(t, "look at this", instructions)
+
+	var input []map[string]any
+	require.NoError(t, json.Unmarshal(request.Input, &input))
+	require.Len(t, input, 1)
+	require.Equal(t, "user", input[0]["role"])
+
+	content, ok := input[0]["content"].([]any)
+	require.True(t, ok)
+	require.Len(t, content, 1)
+}
+
+func TestNormalizeResponsesInputInstructions_MergesWithExistingInstructions(t *testing.T) {
+	request := &dto.OpenAIResponsesRequest{
+		Instructions: json.RawMessage(`"top-level instructions"`),
+		Input: json.RawMessage(`[
+			{"role":"developer","content":"embedded instructions"},
+			{"role":"user","content":"hi"}
+		]`),
+	}
+
+	err := normalizeResponsesInputInstructions(request)
+	require.NoError(t, err)
+
+	var instructions string
+	require.NoError(t, json.Unmarshal(request.Instructions, &instructions))
+	require.Equal(t, "top-level instructions\nembedded instructions", instructions)
+}
+
+func TestNormalizeResponsesInputInstructions_NoSystemOrDeveloperMessage_NoOp(t *testing.T) {
+	original := json.RawMessage(`[{"role":"user","content":"hi"}]`)
+	request := &dto.OpenAIResponsesRequest{
+		Input: original,
+	}
+
+	err := normalizeResponsesInputInstructions(request)
+	require.NoError(t, err)
+	require.Nil(t, request.Instructions)
+	require.JSONEq(t, string(original), string(request.Input))
+}
+
+func TestNormalizeResponsesInputInstructions_PlainStringInput_NoOp(t *testing.T) {
+	request := &dto.OpenAIResponsesRequest{
+		Input: json.RawMessage(`"hi"`),
+	}
+
+	err := normalizeResponsesInputInstructions(request)
+	require.NoError(t, err)
+	require.Nil(t, request.Instructions)
+}
+
+func TestNormalizeResponsesInputInstructions_SkipsResponsesLiteBundle(t *testing.T) {
+	// Responses Lite requests deliberately keep base instructions as a
+	// developer message in `input` alongside an `additional_tools` bundle;
+	// that shape must be left untouched.
+	original := json.RawMessage(`[
+		{"type":"additional_tools","role":"developer","tools":[]},
+		{"role":"developer","content":"lite base instructions"},
+		{"role":"user","content":"hi"}
+	]`)
+	request := &dto.OpenAIResponsesRequest{
+		Input: original,
+	}
+
+	err := normalizeResponsesInputInstructions(request)
+	require.NoError(t, err)
+	require.Nil(t, request.Instructions)
+	require.JSONEq(t, string(original), string(request.Input))
+}
+
+func TestNormalizeResponsesInputInstructions_PreservesTypedNonMessageDirective(t *testing.T) {
+	request := &dto.OpenAIResponsesRequest{
+		Input: json.RawMessage(`[
+			{"type":"custom_directive","role":"developer","payload":"x"},
+			{"role":"system","content":"real instructions"},
+			{"role":"user","content":"hi"}
+		]`),
+	}
+
+	err := normalizeResponsesInputInstructions(request)
+	require.NoError(t, err)
+
+	var instructions string
+	require.NoError(t, json.Unmarshal(request.Instructions, &instructions))
+	require.Equal(t, "real instructions", instructions)
+
+	var input []map[string]any
+	require.NoError(t, json.Unmarshal(request.Input, &input))
+	require.Len(t, input, 2)
+	require.Equal(t, "custom_directive", input[0]["type"])
+	require.Equal(t, "user", input[1]["role"])
+}


### PR DESCRIPTION
Generic OpenAI Responses clients (e.g. Pi's openai-responses provider) embed the system prompt as a system/developer message inside `input` instead of populating the top-level `instructions` field the way Codex-native clients (Codex CLI, Pi's openai-codex provider) do.

Forwarding that shape to the Codex backend unmodified previously left `instructions` empty and the system prompt buried in `input`, which is structurally different from what Codex-native traffic sends. Codex's own prompt-cache prefix matching treats `instructions` as a distinct, stable preamble segment from `input`, so this mismatch can reduce prompt-cache hit reliability even though the content is identical.

This mirrors the 'instruction hoisting' step used by other Responses-API-compatible Codex proxies (e.g. github.com/Soju06/codex-lb) to keep the wire shape Codex-native: leading system/developer 'message' items are extracted from `input` and merged into `instructions` (composing with any channel-level system prompt override already applied afterwards). Non-message typed system/developer items (the Responses-lite additional_tools bundle) and any non-text content parts (e.g. images) are preserved untouched rather than dropped.

# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
(简述：做了什么？为什么这样改能生效？请基于你对代码逻辑的理解来写，避免粘贴未经整理的内容)

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (如有)

## ✅ 提交前检查项 / Checklist
- [ ] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [ ] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [ ] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [ ] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [ ] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [ ] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [ ] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)
